### PR TITLE
Reset Unread Count

### DIFF
--- a/data/icon_notifications.js
+++ b/data/icon_notifications.js
@@ -86,13 +86,13 @@ function getPrettyNumber(number){
     return num;
 }
 
-function setFavicon(count) {
+function setFavicon() {
     var icon = drawIcon();
     var s = document.querySelectorAll("link[rel*='icon'][type='image/png']");
 
     if (s.length != 1 || s[0].href != icon) {
         for(var i = s.length-1; i >= 0; i--){
-        s[i].remove();
+            s[i].remove();
         }
         owaIcon.href = icon;
         document.head.appendChild(owaIcon);
@@ -180,7 +180,7 @@ function getNewUnreadMessageCount() {
     } else {
         newUnreadMessageCount = getCountBasedOffSpans(getContainersBySpanId());
     }
-    return newUnreadMessageCount - currentUnreadMessageCount;
+    return Math.max(newUnreadMessageCount - currentUnreadMessageCount, 0);
 }
 
 function generateMessage(count, isMessage){
@@ -196,7 +196,7 @@ function generateMessage(count, isMessage){
 function notify() {
     if (haveNewMessages()) {
         var newUnreadMessageCount = getNewUnreadMessageCount();
-        setFavicon(newUnreadMessageCount); // Probably unnecessary since you alter the document title. 
+        setFavicon(); // Probably unnecessary since you alter the document title. 
         addCountToDocumentTitle(newUnreadMessageCount);
         self.port.emit("notify", generateMessage(newUnreadMessageCount, true));
         currentUnreadMessageCount = newUnreadMessageCount;

--- a/data/icon_notifications.js
+++ b/data/icon_notifications.js
@@ -180,7 +180,7 @@ function getNewUnreadMessageCount() {
     } else {
         newUnreadMessageCount = getCountBasedOffSpans(getContainersBySpanId());
     }
-    return Math.max(newUnreadMessageCount - currentUnreadMessageCount, 0);
+    return newUnreadMessageCount;
 }
 
 function generateMessage(count, isMessage){
@@ -194,16 +194,18 @@ function generateMessage(count, isMessage){
 }
 
 function notify() {
+    var unread = getNewUnreadMessageCount();
+    
     if (haveNewMessages()) {
-        var newUnreadMessageCount = getNewUnreadMessageCount();
-        setFavicon(); // Probably unnecessary since you alter the document title. 
-        addCountToDocumentTitle(newUnreadMessageCount);
-        self.port.emit("notify", generateMessage(newUnreadMessageCount, true));
-        currentUnreadMessageCount = newUnreadMessageCount;
+        self.port.emit("notify", generateMessage(unread, true));
     }
     if (haveNewReminders()){
         var newReminderCount = getNewReminderCount();
         self.port.emit("notify", generateMessage(newReminderCount, false));
         currentReminderCount = newReminderCount;
     }
+    
+    currentUnreadMessageCount = unread;
+    setFavicon(); // Probably unnecessary since you alter the document title. 
+    addCountToDocumentTitle(currentUnreadMessageCount);
 }

--- a/data/icon_notifications.js
+++ b/data/icon_notifications.js
@@ -2,8 +2,7 @@ var timer;
 var currentUnreadMessageCount = 0;
 var currentReminderCount = 0;
 var documentTitle = document.title;
-var owaIcon = getOwaIcon();
-document.head.appendChild(owaIcon);
+document.head.appendChild(getOwaIcon());
 
 
 self.port.on("startMonitor", function(delayBetweenChecks) {
@@ -94,8 +93,11 @@ function setFavicon() {
         for(var i = s.length-1; i >= 0; i--){
             s[i].remove();
         }
-        owaIcon.href = icon;
-        document.head.appendChild(owaIcon);
+        var newIcon = getOwaIcon();
+        if(currentUnreadMessageCount > 0){
+            newIcon.href = icon;
+        }
+        document.head.appendChild(newIcon);
     }
 }
 


### PR DESCRIPTION
We need to reset the unread count once a user reads an email, instead of leaving the number in the favicon and document title.
